### PR TITLE
Fix duplicated method and sanitize input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,4 +206,3 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 /vendor/
-.env

--- a/public/index.php
+++ b/public/index.php
@@ -24,10 +24,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $options = [];
         // Pass additional options from form
         if (!empty($_POST['entities'])) {
-            $options['entities'] = array_map('trim', explode(',', $_POST['entities']));
+            $entities = array_map('trim', explode(',', $_POST['entities']));
+            $options['entities'] = array_filter($entities, static fn($e) => $e !== '');
         }
-        if (!empty($_POST['score'])) {
-            $options['score_threshold'] = (float) $_POST['score'];
+        if (isset($_POST['score']) && is_numeric(trim($_POST['score']))) {
+            $options['score_threshold'] = (float) trim($_POST['score']);
         }
         $output = $client->analyzeAndAnonymize($input, $options);
     } catch (Exception $e) {

--- a/src/PresidioClient.php
+++ b/src/PresidioClient.php
@@ -103,13 +103,4 @@ class PresidioClient
         $analysis = $this->analyze($text, $options);
         return $this->anonymize($text, $analysis);
     }
-
-    /**
-     * Convenience method to analyze and immediately anonymize text.
-     */
-    public function analyzeAndAnonymize(string $text, array $options = []): string
-    {
-        $analysis = $this->analyze($text, $options);
-        return $this->anonymize($text, $analysis);
-    }
 }


### PR DESCRIPTION
## Summary
- remove duplicate method in `PresidioClient`
- sanitize entities and score parameters in `index.php`
- deduplicate `.env` entry in `.gitignore`

## Testing
- `composer install` *(fails: command not found)*
- `php -l public/index.php` *(fails: command not found)*
- `php -l src/PresidioClient.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a6ee0b848328baba6d0e07d0e499