### PR TITLE
Update copy button location and sync text boxes

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -58,20 +58,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
               <div class="col-md-6">
                 <div class="mb-3">
                   <label class="form-label">Input Text</label>
-                  <textarea name="input_text" class="form-control resize-sync" rows="10" style="min-height:200px; resize:vertical; overflow:hidden;"><?= htmlspecialchars($input) ?></textarea>
+                  <textarea name="input_text" class="form-control resize-sync" rows="10" style="min-height:200px; resize:none; overflow:hidden;"><?= htmlspecialchars($input) ?></textarea>
                 </div>
               </div>
               <div class="col-md-6">
                 <div class="mb-3 position-relative">
                   <label class="form-label">Anonymized Output</label>
-                  <button type="button" id="copyOutput" class="btn btn-sm btn-outline-secondary position-absolute start-0 top-0 m-2" title="Copy">
+                  <button type="button" id="copyOutput" class="btn btn-sm btn-outline-secondary position-absolute end-0 top-0 m-2" title="Copy">
                     <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="16" height="16" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                       <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
                       <rect x="8" y="8" width="12" height="12" rx="2" />
                       <path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2" />
                     </svg>
                   </button>
-                  <textarea class="form-control resize-sync" rows="10" style="min-height:200px; resize:vertical; overflow:hidden;" readonly><?= htmlspecialchars($output) ?></textarea>
+                  <textarea class="form-control resize-sync" rows="10" style="min-height:200px; resize:none; overflow:hidden;" readonly><?= htmlspecialchars($output) ?></textarea>
                 </div>
               </div>
             </div>
@@ -110,15 +110,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         const outputArea = document.querySelector('textarea[readonly]');
         const copyBtn = document.getElementById('copyOutput');
 
-        function autoResize(el) {
-          el.style.height = 'auto';
-          el.style.height = el.scrollHeight + 'px';
+        function syncResize() {
+          inputArea.style.height = 'auto';
+          outputArea.style.height = 'auto';
+          const maxHeight = Math.max(inputArea.scrollHeight, outputArea.scrollHeight);
+          inputArea.style.height = maxHeight + 'px';
+          outputArea.style.height = maxHeight + 'px';
         }
 
-        [inputArea, outputArea].forEach(el => {
-          autoResize(el);
-          el.addEventListener('input', () => autoResize(el));
-        });
+        syncResize();
+        inputArea.addEventListener('input', syncResize);
 
 
         if (copyBtn) {


### PR DESCRIPTION
## Summary
- position the copy button in the right corner
- disable manual textarea resizing
- keep input and output textareas in sync

## Testing
- `composer install` *(fails: command not found)*
- `php -l public/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866c5bc857c832882ee61589561ab22